### PR TITLE
Make the whitespace on OxyMessage consistent.

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -16,9 +16,9 @@ pub enum OxyMessage {
 	FileData { reference: u64, data: Vec<u8> },
 	RemoteOpen { addr: String },
 	RemoteBind { addr: String },
-    RemoteStreamData { reference: u64, data: Vec<u8> },
-    LocalStreamData { reference: u64, data: Vec<u8> },
+	RemoteStreamData { reference: u64, data: Vec<u8> },
+	LocalStreamData { reference: u64, data: Vec<u8> },
 	BindConnectionAccepted { reference: u64 },
-    TunnelRequest { tap: bool, name: String },
-    TunnelData { reference: u64, data: Vec<u8> },
+	TunnelRequest { tap: bool, name: String },
+	TunnelData { reference: u64, data: Vec<u8> },
 }


### PR DESCRIPTION
It's marked rustfmt_skip because the entire enum shouldn't go into long-struct mode when one variant requires going into long-struct mode, but that has some drawbacks