### PR TITLE
Fix armv7 compilation

### DIFF
--- a/src/core/handle_message.rs
+++ b/src/core/handle_message.rs
@@ -3,6 +3,8 @@ use super::{PortBind, PortStream};
 use crate::pty::Pty;
 #[cfg(unix)]
 use crate::tuntap::{TunTap, TunTapType};
+#[cfg(unix)]
+use libc::off_t;
 use crate::{
     core::Oxy,
     message::OxyMessage::{self, *},
@@ -344,7 +346,7 @@ impl Oxy {
                         .truncate(false)
                         .open(path)
                         .map_err(|_| "Failed to open file")?;
-                    let result = ::nix::unistd::ftruncate(file.as_raw_fd(), len as i64);
+                    let result = ::nix::unistd::ftruncate(file.as_raw_fd(), len as off_t);
                     if result.is_err() {
                         return Err("Truncate failed".to_string());
                     }

--- a/src/tuntap.rs
+++ b/src/tuntap.rs
@@ -1,6 +1,6 @@
 use byteorder::{self, ByteOrder};
 use crate::core::Oxy;
-use libc::ioctl;
+use libc::{c_ulong, ioctl};
 #[allow(unused_imports)]
 use log::{debug, error, info, log, trace, warn};
 use nix::{
@@ -34,7 +34,7 @@ pub(crate) enum TunTapType {
 const IFF_TUN: u16 = 1;
 const IFF_TAP: u16 = 2;
 const IFF_NO_PI: u16 = 4096;
-const TUNSETIFF: u64 = 1074025674;
+const TUNSETIFF: c_ulong = 1074025674;
 
 impl TunTap {
     crate fn create(mode: TunTapType, name: &str, reference_number: u64, oxy: Oxy) -> TunTap {


### PR DESCRIPTION
While building oxy for an armv7-unknown-linux-gnueabihf target, I encountered these errors:

```rust
error[E0308]: mismatched types
   --> src/core/handle_message.rs:347:77
    |
347 |                     let result = ::nix::unistd::ftruncate(file.as_raw_fd(), len as i64);
    |                                                                             ^^^^^^^^^^ expected i32, found i64
error[E0308]: mismatched types
  --> src/tuntap.rs:53:28
   |
53 |         unsafe { ioctl(fd, TUNSETIFF, &buf[..18]) };
   |                            ^^^^^^^^^ expected u32, found u64
```

The ftruncate argument is `off_t` in nix, so I import and use that.

The ioctl argument is stranger: it's `int` in `linux/if_tun.h`, but `nix::c_ulong` compiles on both x86-64 and armv7. I haven't tested if TUN/TAP still works. Could you take a look?